### PR TITLE
Feat/task details

### DIFF
--- a/streamline/app/Http/Controllers/TaskController.php
+++ b/streamline/app/Http/Controllers/TaskController.php
@@ -29,7 +29,7 @@ class TaskController extends Controller
     {
         //TODO: Validation 
         $task = new \App\Task;
-        $task -> ownerId = 0;
+        $task -> ownerId = $request -> input('userID');
         $task -> title = $request -> get('title');
         $task -> body = $request -> get('body');
         $task -> workedDuration = 0;
@@ -54,6 +54,18 @@ class TaskController extends Controller
     {
         $task = \App\Task::find($id);
         return $task;
+    }
+
+    /**
+     * Display all tags that belong to the user with userID
+     * 
+     * @param Request $request 
+     * @return \Illuminate\Http\Response
+     */
+    public function list(Request $request){
+        $userID = (int)($request -> userID);
+        $tags = DB::table('tasks')->where('ownerId', '=', $userID)->get(['id', 'title', 'body', 'estimatedMin', 'estimatedHour']);
+        return  response()->json($tags);
     }
 
     /**

--- a/streamline/app/Http/Controllers/TaskController.php
+++ b/streamline/app/Http/Controllers/TaskController.php
@@ -57,15 +57,15 @@ class TaskController extends Controller
     }
 
     /**
-     * Display all tags that belong to the user with userID
+     * Display all tasks that belong to the user with userID
      * 
      * @param Request $request 
      * @return \Illuminate\Http\Response
      */
     public function list(Request $request){
         $userID = (int)($request -> userID);
-        $tags = DB::table('tasks')->where('ownerId', '=', $userID)->get(['id', 'title', 'body', 'estimatedMin', 'estimatedHour']);
-        return  response()->json($tags);
+        $tasks = DB::table('tasks')->where('ownerId', '=', $userID)->get(['id', 'title', 'body', 'estimatedMin', 'estimatedHour']);
+        return  response()->json($tasks);
     }
 
     /**

--- a/streamline/routes/api.php
+++ b/streamline/routes/api.php
@@ -11,8 +11,10 @@
 |
 */
 
-
+/* Task Routes ------- */
 Route::resource('tasks', 'TaskController');
+Route::get('tasks', 'TaskController@list');
+/* ------------------ */
 
 /* Tag Routes -------*/
 Route::post('tags', 'TagController@store');


### PR DESCRIPTION
1. Server can now send back all of the tasks based on the provided userID from front end

2. Removed hard-coded `ownerId` in the create_tasks migration